### PR TITLE
Sort translation stats by percentage

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,7 +191,7 @@ const buildTranslationTable = translationStats => {
   output += "|language|translated|untranslated|percentage done|\n"
   output += "|--------|----------|------------|---------------|\n"
   for(const stat of translationStats){
-    output += `|${stat.language}${stat.hasStar ? ":star:" : ""}|${stat.translated}|${stat.untranslated}|${stat.percentage}%|\n`
+    output += `|${stat.hasStar ? ":star:" : ""}${stat.language}|${stat.translated}|${stat.untranslated}|${stat.percentage}%|\n`
   }
   output += "\n"
   return output


### PR DESCRIPTION
This makes it easier to see at a glance, where we stand at. The languages that get a star in Mudlet and the stats output now also get a star here. This closes #63

See https://github.com/keneanung/Add-DeploymentLinks-Test/pull/35 for an example.