### PR TITLE
fix regex for windows replacement and properly flatten link array output

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,8 @@ const getCommentTemplate = title =>
   "You can directly test the changes here:\n" +
   "- linux: (download pending, check back soon!)\n" +
   "- osx: (download pending, check back soon!)\n" +
-  "- windows (x64): (download pending, check back soon!)\n\n" +
-  "- windows (x32): (download pending, check back soon!)\n\n" +
+  "- windows 64 bit: (download pending, check back soon!)\n" +
+  "- windows 32 bit: (download pending, check back soon!)\n\n" +
   "No need to install anything - just unzip and run.\n" +
   "Let us know if it works well, and if it doesn't, please give details.\n" +
   (title === "Improve: New Crowdin updates"
@@ -105,13 +105,10 @@ const getMudletSnapshotLinksForPr = async prNumber => {
       // for other platforms, take only the latest link
       return value[0] ? [value[0]] : []
     })
-    // flatten the object into an array
-    .reduce((result, value) => {
-      result.push(value)
-      return result
-    }, [])
     // remove undefined values
     .filter(value => value !== undefined)
+    .values()
+    .flatten()
     .value()
   return latestLinks
 }
@@ -135,9 +132,9 @@ const setDeploymentLinks = async (repositoryOwner, repositoryName, prNumber, git
   for(const pair of links){
     if (pair.platform === 'windows') {
       if (/windows-64/.test(pair.url)) {
-        pair.platform = 'windows (x64)';
+        pair.platform = 'windows 64 bit';
       } else if (/windows-32/.test(pair.url)) {
-        pair.platform = 'windows (x32)';
+        pair.platform = 'windows 32 bit';
       }
     }
     updateCommentUrl(pair.platform, pair.url, deploymentComment)


### PR DESCRIPTION
The links need to be in a completely flat array whereas my previous PR put the windows links nested an additional level.

Additionally the regex for capturing windows (x32) would need some escaping, instead of that I modified the text to simply be 'windows 32 bit' or 'windows 64 bit' requiring no additional escapes.

This is the output from my local test:
```
Snapshot links: [
  {
    url: 'https://make.mudlet.org/snapshots/dcd5a8/Mudlet-4.17.2-testing-pr7227-1039a4dc-windows-64.zip',
    prid: '7227',
    commitid: '1039a4dc',
    platform: 'windows',
    creation_time: '2024-05-19T19:28:29+00:00'
  },
  {
    url: 'https://make.mudlet.org/snapshots/857c3d/Mudlet-4.17.2-testing-pr7227-1039a4dc-windows-32.zip',
    prid: '7227',
    commitid: '1039a4dc',
    platform: 'windows',
    creation_time: '2024-05-19T19:25:28+00:00'
  },
  {
    url: 'https://make.mudlet.org/snapshots/17eafc/Mudlet-4.17.2-testing-pr7227-1039a4dc-linux-x64.AppImage.tar',
    prid: '7227',
    commitid: '1039a4dc',
    platform: 'linux',
    creation_time: '2024-05-19T19:18:41+00:00'
  },
  {
    url: 'https://make.mudlet.org/snapshots/b61ccb/Mudlet-4.17.2-testing-pr7227-1039a4dc.dmg',
    prid: '7227',
    commitid: '1039a4dc',
    platform: 'osx',
    creation_time: '2024-05-19T19:23:23+00:00'
  }
]
New deployment body:
Hey there! Thanks for helping Mudlet improve. :star2:

## Test versions

You can directly test the changes here:
- linux: https://make.mudlet.org/snapshots/17eafc/Mudlet-4.17.2-testing-pr7227-1039a4dc-linux-x64.AppImage.tar
- osx: https://make.mudlet.org/snapshots/b61ccb/Mudlet-4.17.2-testing-pr7227-1039a4dc.dmg
- windows 64 bit: https://make.mudlet.org/snapshots/dcd5a8/Mudlet-4.17.2-testing-pr7227-1039a4dc-windows-64.zip
- windows 32 bit: https://make.mudlet.org/snapshots/857c3d/Mudlet-4.17.2-testing-pr7227-1039a4dc-windows-32.zip

No need to install anything - just unzip and run.
Let us know if it works well, and if it doesn't, please give details.```