### PR TITLE
Revert probot version - requires node18

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "js-yaml": "^4.1.0",
-    "probot": "^13.2.0",
+    "probot": "^12.3.0",
     "xmlhttprequest": "^1.8.0",
     "lodash": "^4.17.21",
     "axios": "^1.3.3",


### PR DESCRIPTION
Glitch only supports node16 at the moment: https://help.glitch.com/hc/en-us/articles/16287495688845-What-version-of-Node-can-I-use-and-how-do-I-change-update-upgrade-it